### PR TITLE
Corrections sur la pipeline d'intégration 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,12 +19,14 @@ jobs:
       with:
         go-version: 1.18.1
 
-    - name: Build and functional tests
-      run: ./build-and-test.sh
+    - name: Build 
+      run: 
+        - mkdir ./cache
+        - ./tests/functional-testing.py --build  --origin-path ./ --cache-path ./cache
       
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ./faass
+        name: faass
         path: ./faass
         retention-days: 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,9 +3,9 @@ name: Go
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "pipeline" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "pipeline" ]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       run: mkdir ./cache
 
     - name: Build 
-      run: ./tests/functional-testing.py --build  --origin-path ./ --cache-path ./cache
+      run: ./tests/functional-testing.py --build  --origin-path `pwd` --cache-path `pwd`/cache
       
     - name: Upload Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,11 @@ jobs:
       with:
         go-version: 1.18.1
 
+    - name: Define local Go cache 
+      run: mkdir ./cache
+
     - name: Build 
-      run: 
-        - mkdir ./cache
-        - ./tests/functional-testing.py --build  --origin-path ./ --cache-path ./cache
+      run: ./tests/functional-testing.py --build  --origin-path ./ --cache-path ./cache
       
     - name: Upload Artifact
       uses: actions/upload-artifact@v3

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -6,29 +6,59 @@ import (
 )
 
 type Logger struct {
-  Debug       func(v ...any)
-  Debugf      func(f string, v ...any)
-  Info        func(v ...any)
-  Infof       func(f string, v ...any)
-  Warning     func(v ...any)
-  Warningf    func(f string, v ...any)
-  Error       func(v ...any)
-  Errorf      func(f string, v ...any)
-  Panic       func(v ...any)
-  Panicf      func(f string, v ...any)
+  debugRealLogger       *log.Logger
+  infoRealLogger        *log.Logger
+  warningRealLogger     *log.Logger
+  errorRealLogger       *log.Logger
+  panicRealLogger       *log.Logger
+}
+
+func ( logger *Logger ) Debug ( v ...interface{} ) {
+  logger.debugRealLogger.Println( v... ) 
+}
+
+func ( logger *Logger ) Debugf ( f string, v ...interface{} ) {
+  logger.debugRealLogger.Printf( f, v... ) 
+}
+
+func ( logger *Logger ) Info ( v ...interface{} ) {
+  logger.infoRealLogger.Println( v... ) 
+}
+
+func ( logger *Logger ) Infof ( f string, v ...interface{} ) {
+  logger.infoRealLogger.Printf( f, v... ) 
+}
+
+func ( logger *Logger ) Error ( v ...interface{} ) {
+  logger.errorRealLogger.Println( v... ) 
+}
+
+func ( logger *Logger ) Errorf ( f string, v ...interface{} ) {
+  logger.errorRealLogger.Printf( f, v... ) 
+}
+
+func ( logger *Logger ) Warning ( v ...interface{} ) {
+  logger.warningRealLogger.Println( v... ) 
+}
+
+func ( logger *Logger ) Warningf ( f string, v ...interface{} ) {
+  logger.warningRealLogger.Printf( f, v... ) 
+}
+
+func ( logger *Logger ) Panic ( v ...interface{} ) {
+  logger.panicRealLogger.Println( v... ) 
+}
+
+func ( logger *Logger ) Panicf ( f string, v ...interface{} ) {
+  logger.panicRealLogger.Printf( f, v... ) 
 }
 
 func ( logger *Logger ) Init() {
-  logger.Debug      = log.New( os.Stdout, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile ).Println
-  logger.Debugf     = log.New( os.Stdout, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile ).Printf
-  logger.Info       = log.New( os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile ).Println
-  logger.Infof      = log.New( os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile ).Printf
-  logger.Warning    = log.New( os.Stderr, "WARNING: ", log.Ldate|log.Ltime|log.Lshortfile ).Println
-  logger.Warningf   = log.New( os.Stderr, "WARNING: ", log.Ldate|log.Ltime|log.Lshortfile ).Printf
-  logger.Error      = log.New( os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile ).Println
-  logger.Errorf     = log.New( os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile ).Printf
-  logger.Panic      = log.New( os.Stderr, "PANIC: ", log.Ldate|log.Ltime|log.Lshortfile ).Println
-  logger.Panicf     = log.New( os.Stderr, "PANIC: ", log.Ldate|log.Ltime|log.Lshortfile ).Printf
+  logger.debugRealLogger      = log.New( os.Stdout, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile )
+  logger.infoRealLogger       = log.New( os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile )
+  logger.warningRealLogger    = log.New( os.Stdout, "WARNING: ", log.Ldate|log.Ltime|log.Lshortfile )
+  logger.errorRealLogger      = log.New( os.Stdout, "IERROR: ", log.Ldate|log.Ltime|log.Lshortfile )
+  logger.panicRealLogger      = log.New( os.Stdout, "PANIC: ", log.Ldate|log.Ltime|log.Lshortfile )
 }
 
 func ( logger *Logger ) Test ( m string ) bool {


### PR DESCRIPTION
- Remplacement de `any` par `interface{}` dans le module Logger du projet 
- Ajout du support d'une branche `pipeline` pour le déclencheur Github Action 
- Correctif de la pipeline avec restriction sur l'étape seule de construction 